### PR TITLE
Add missing setup steps

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,6 +27,12 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
+  
+  puts "\n== Enabling caching in development =="
+  system! "rails dev:cache"
+  
+  puts "\n== Precompiling assets =="
+  system! "rake assets:precompile"
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"


### PR DESCRIPTION
I figured that we should turn on caching and precompile the assets, to avoid sprockets issues.