### PR TITLE
Setup order of operations

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -21,15 +21,15 @@ FileUtils.chdir APP_ROOT do
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
+  
+  puts "\n== Enabling caching in development =="
+  system! "rails dev:cache"
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
-  
-  puts "\n== Enabling caching in development =="
-  system! "rails dev:cache"
   
   puts "\n== Precompiling assets =="
   system! "rake assets:precompile"


### PR DESCRIPTION
`db:prepare` gets upset if caching is not already enabled.