### PR TITLE
Setup Gitpod with Postgres

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,8 @@
 image:
   file: gitpod.Dockerfile
 ports:
+  - port: 5432
+    onOpen: ignore
   - port: 3000
     onOpen: open-preview
   - port: 6379

--- a/gitpod.Dockerfile
+++ b/gitpod.Dockerfile
@@ -1,4 +1,5 @@
 FROM gitpod/workspace-ruby-3.1
+FROM gitpod/workspace-postgres
 
 RUN curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
@@ -9,6 +10,6 @@ RUN sudo apt-get update
 RUN sudo apt-get install -y git-core zlib1g-dev build-essential libssl-dev \
 libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev \
 libcurl4-openssl-dev software-properties-common libffi-dev nodejs yarn \
-redis-server
+postgresql-12 libpq-dev redis-server
 
 RUN sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Setup Gitpod with Postgres to fix the issue I mentioned here https://github.com/marcoroth/rails7-stimulus-reflex-esbuild/pull/6#issuecomment-1200274171.

You might want to test this yourself before merging by opening this URL: https://gitpod.io/#https://github.com/marcoroth/rails7-stimulus-reflex-esbuild/pull/7

The first build will be slow but the subsequent builds will reuse the cached image layers, so it will be faster.